### PR TITLE
Catch HTTP client request exceptions

### DIFF
--- a/lib/pingback.js
+++ b/lib/pingback.js
@@ -484,6 +484,8 @@ var request = function(url, body, func) {
     // an agent socket's `end` sometimes
     // wont be emitted on the response
     res.socket.on('end', end);
+  }).on('error', function(err) {
+    func(err);
   });
   req.end(body);
 };


### PR DESCRIPTION
The application crashes if a HTTP client request exceptions occur while sending pingbacks:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: getaddrinfo EIO
    at errnoException (dns.js:37:11)
    at Object.onanswer [as oncomplete] (dns.js:124:16)
Program node app.js exited with code 8
```

or

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: connect ECONNREFUSED
    at errnoException (net.js:905:11)
    at Object.afterConnect [as oncomplete] (net.js:896:19)
Program node app.js exited with code 8
```

If the 'error' event of the request is handled, the application will no longer crash.

See also http://stackoverflow.com/questions/4328540/how-to-catch-http-client-request-exceptions-in-node-js
